### PR TITLE
Fix Missing Initializations

### DIFF
--- a/src/drivers/dataspeed_ford_interface/src/dataspeed_ford_interface.cpp
+++ b/src/drivers/dataspeed_ford_interface/src/dataspeed_ford_interface.cpp
@@ -104,6 +104,7 @@ DataspeedFordInterface::DataspeedFordInterface(
   m_misc_cmd.cmd.value = TurnSignal::NONE;
 
   m_timer = node.create_wall_timer(m_pub_period, std::bind(&DataspeedFordInterface::cmdCallback, this));
+  m_prev_tick = m_clock.now();
 }
 
 void DataspeedFordInterface::cmdCallback()


### PR DESCRIPTION
initialize m_prev_tick to rclcpp::now() upon construction