### PR TITLE
Add missing dependencies for Dataspeed driver build

### DIFF
--- a/autoware.auto.foxy.repos
+++ b/autoware.auto.foxy.repos
@@ -15,7 +15,15 @@ repositories:
     type: git
     url: https://github.com/f1tenth/vesc
     version: ros2
-  src/external/dbw_ros:
+  src/external/dataspeed:
     type: git
     url: https://bitbucket.org/DataspeedInc/dbw_ros.git
+    version: ros2
+  src/external/dataspeed_can:
+    type: git
+    url: https://bitbucket.org/DataspeedInc/dataspeed_can.git
+    version: ros2
+  src/external/lusb:
+    type: git
+    url: https://bitbucket.org/DataspeedInc/lusb.git
     version: ros2


### PR DESCRIPTION
As instructed from the Autoware Bootcamp Day 1, fixed missing Dataspeed dependencies