### PR TITLE
Fix NDT Mapper Node Error Logs

### DIFF
--- a/src/mapping/ndt_mapping_nodes/include/ndt_mapping_nodes/ndt_mapping_nodes.hpp
+++ b/src/mapping/ndt_mapping_nodes/include/ndt_mapping_nodes/ndt_mapping_nodes.hpp
@@ -243,7 +243,7 @@ private:
       m_map_ptr->update(increment);
       m_previous_transform = pose_to_transform(pose_out, msg_ptr->header.frame_id);
     } catch (const std::runtime_error & e) {
-      RCLCPP_ERROR(get_logger(), "Failed to register the measurement: ", e.what());
+      RCLCPP_ERROR(get_logger(), "Failed to register the measurement: %s", e.what());
     }
   }
 


### PR DESCRIPTION
NDT mapper node does not attach exception error msgs to RCLCPP_ERROR, which is not intuitive for debugging.

This PR appends the error msg at the end of output. 