### PR TITLE
Ouster Lidar Support

### DIFF
--- a/autoware.auto.foxy.repos
+++ b/autoware.auto.foxy.repos
@@ -33,5 +33,5 @@ repositories:
     version: ros2
   src/external/bootcamp/bootcamp_launch:
     type: git
-    url: https://gitlab.com/shineyruan/bootcamp_launch_autoware_auto.git
+    url: https://github.com/shineyruan/bootcamp_launch.git
     version: main

--- a/autoware.auto.foxy.repos
+++ b/autoware.auto.foxy.repos
@@ -27,3 +27,11 @@ repositories:
     type: git
     url: https://bitbucket.org/DataspeedInc/lusb.git
     version: ros2
+  src/external/ouster/ros2_driver:
+    type: git
+    url: https://github.com/ros-drivers/ros2_ouster_drivers.git
+    version: ros2
+  src/external/bootcamp/bootcamp_launch:
+    type: git
+    url: https://gitlab.com/shineyruan/bootcamp_launch_autoware_auto.git
+    version: main

--- a/src/localization/ndt_nodes/src/map_publisher.cpp
+++ b/src/localization/ndt_nodes/src/map_publisher.cpp
@@ -127,6 +127,7 @@ void NDTMapPublisherNode::init(
       std::chrono::seconds(1),
       [this]() {
         if (m_downsampled_pc.width > 0U) {
+          m_downsampled_pc.header.frame_id = "map";
           m_viz_pub->publish(m_downsampled_pc);
         }
       });
@@ -197,6 +198,7 @@ void NDTMapPublisherNode::downsample_pc()
 void NDTMapPublisherNode::publish()
 {
   if (m_map_pc.width > 0U) {
+    m_map_pc.header.frame_id = "map";
     m_pub->publish(m_map_pc);
   }
 }

--- a/src/tools/point_type_adapter/src/point_type_adapter_node.cpp
+++ b/src/tools/point_type_adapter/src/point_type_adapter_node.cpp
@@ -45,7 +45,7 @@ PointTypeAdapterNode::PointTypeAdapterNode(const rclcpp::NodeOptions & options)
   ,
   sub_ptr_cloud_input_(this->create_subscription<PointCloud2>(
       "points_raw",
-      rclcpp::QoS(rclcpp::KeepLast(::QOS_HISTORY_DEPTH)),
+      rclcpp::SensorDataQoS(rclcpp::KeepLast(::QOS_HISTORY_DEPTH)),
       std::bind(&PointTypeAdapterNode::callback_cloud_input,
       this,
       std::placeholders::_1)))


### PR DESCRIPTION
This PR adds supports for the Ouster Lidar from mLab at Penn.

Current progress: 
* ROS2 Ouster Lidar driver runs successful
* Lidar raw data access successful
* NDT Mapping node runs successful (localization not verified)